### PR TITLE
Handle oauth headers appropriately

### DIFF
--- a/aiera_mcp/__init__.py
+++ b/aiera_mcp/__init__.py
@@ -141,6 +141,16 @@ from .tools.transcrippets import (
 # Import configuration
 from .config import get_settings, reload_settings, AieraSettings
 
+# Import context providers
+from .context import (
+    set_request_context_provider,
+    get_request_context,
+    clear_request_context_provider,
+    set_error_handler,
+    handle_api_error,
+    clear_error_handler,
+)
+
 # Import utilities
 from .tools.base import make_aiera_request, AIERA_BASE_URL, CITATION_PROMPT
 from .tools.utils import (
@@ -194,6 +204,13 @@ __all__ = [
     "set_api_key_provider",
     "get_api_key",
     "clear_api_key_provider",
+    # Context Providers
+    "set_request_context_provider",
+    "get_request_context",
+    "clear_request_context_provider",
+    "set_error_handler",
+    "handle_api_error",
+    "clear_error_handler",
     # Configuration
     "get_settings",
     "reload_settings",

--- a/aiera_mcp/_version.py
+++ b/aiera_mcp/_version.py
@@ -28,7 +28,7 @@ version_tuple: VERSION_TUPLE
 commit_id: COMMIT_ID
 __commit_id__: COMMIT_ID
 
-__version__ = version = "0.2.dev0+g7b38080d9.d20251124"
-__version_tuple__ = version_tuple = (0, 2, "dev0", "g7b38080d9.d20251124")
+__version__ = version = "0.2.dev7+g1e3ebe10c.d20251201"
+__version_tuple__ = version_tuple = (0, 2, "dev7", "g1e3ebe10c.d20251201")
 
 __commit_id__ = commit_id = None

--- a/aiera_mcp/context.py
+++ b/aiera_mcp/context.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Context provider infrastructure for request customization.
+
+This module provides a plugin system for injecting deployment-specific context
+(headers, metadata, error handling) into API requests without modifying tool code.
+
+Example:
+    # In aiera-public-mcp server.py:
+    from aiera_mcp import set_request_context_provider, set_error_handler
+    from .mcp_context import create_request_context, create_oauth_error_handler
+
+    # Configure context injection at startup
+    set_request_context_provider(create_request_context)
+    set_error_handler(create_oauth_error_handler)
+
+    # Now all tools will automatically include OAuth context in requests
+"""
+
+import logging
+from typing import Dict, Any, Optional, Callable
+
+logger = logging.getLogger(__name__)
+
+# Global context provider - returns headers and metadata for current request
+_request_context_provider: Optional[Callable[[], Dict[str, Any]]] = None
+
+# Global error handler - creates appropriate exceptions for API errors
+_error_handler: Optional[Callable[[int, str, str], Exception]] = None
+
+
+def set_request_context_provider(provider: Callable[[], Dict[str, Any]]) -> None:
+    """Configure a function that provides request context (headers, metadata).
+
+    The provider function should return a dictionary with the following structure:
+    {
+        "headers": {
+            "X-Custom-Header": "value",
+            ...
+        },
+        "log_metadata": {
+            "user_id": "12345",
+            "stage": "prod",
+            ...
+        }
+    }
+
+    Args:
+        provider: A callable that returns a context dictionary
+
+    Example:
+        def my_context_provider():
+            return {
+                "headers": {
+                    "X-MCP-Origin": "remote_mcp_prod",
+                    "X-User-ID": get_current_user_id(),
+                },
+                "log_metadata": {
+                    "user_id": get_current_user_id(),
+                    "stage": "prod",
+                }
+            }
+
+        set_request_context_provider(my_context_provider)
+    """
+    global _request_context_provider
+    _request_context_provider = provider
+    logger.info("Request context provider configured")
+
+
+def get_request_context() -> Dict[str, Any]:
+    """Get current request context from configured provider.
+
+    Returns:
+        Dictionary with 'headers' and 'log_metadata' keys, or empty dict if no provider
+
+    Example:
+        context = get_request_context()
+        headers = context.get("headers", {})
+        metadata = context.get("log_metadata", {})
+    """
+    if _request_context_provider:
+        try:
+            context = _request_context_provider()
+            logger.debug(
+                f"Retrieved context with {len(context.get('headers', {}))} headers"
+            )
+            return context
+        except Exception as e:
+            logger.warning(f"Context provider failed: {e}", exc_info=True)
+            # Return empty context on failure to avoid breaking requests
+            return {}
+
+    # No provider configured - return empty context
+    return {}
+
+
+def clear_request_context_provider() -> None:
+    """Clear the configured context provider (mainly for testing)."""
+    global _request_context_provider
+    _request_context_provider = None
+    logger.info("Request context provider cleared")
+
+
+def set_error_handler(handler: Callable[[int, str, str], Exception]) -> None:
+    """Configure custom error handler for API failures.
+
+    The error handler receives the HTTP status code, endpoint, and response text,
+    and should return an appropriate Exception to raise.
+
+    Args:
+        handler: A callable that takes (status_code, endpoint, response_text) and returns Exception
+
+    Example:
+        def my_error_handler(status_code: int, endpoint: str, response_text: str) -> Exception:
+            if status_code == 401:
+                return OAuthAuthenticationError("Please re-authenticate")
+            else:
+                return Exception(f"API error {status_code}: {response_text}")
+
+        set_error_handler(my_error_handler)
+    """
+    global _error_handler
+    _error_handler = handler
+    logger.info("Custom error handler configured")
+
+
+def handle_api_error(status_code: int, endpoint: str, response_text: str) -> Exception:
+    """Handle API error using custom handler if configured.
+
+    Args:
+        status_code: HTTP status code from API response
+        endpoint: API endpoint that was called
+        response_text: Response body text
+
+    Returns:
+        Exception to raise (either custom or default)
+
+    Example:
+        exception = handle_api_error(401, "/events", "Unauthorized")
+        raise exception
+    """
+    if _error_handler:
+        try:
+            error = _error_handler(status_code, endpoint, response_text)
+            logger.debug(f"Custom error handler created {type(error).__name__}")
+            return error
+        except Exception as e:
+            logger.warning(f"Error handler failed: {e}", exc_info=True)
+            # Fall through to default handler
+
+    # Default error handling
+    if status_code in [401, 403]:
+        return Exception(
+            f"Aiera API authentication failed (HTTP {status_code}). "
+            f"The API key may be invalid or expired."
+        )
+    elif status_code == 404:
+        return Exception(
+            f"Aiera API endpoint not found: {endpoint}. "
+            f"This might indicate an incorrect endpoint or missing API access."
+        )
+    elif status_code == 504:
+        return Exception(
+            f"API request timed out (504). "
+            f"The API endpoint may be experiencing heavy load. Please retry in a moment."
+        )
+    else:
+        return Exception(f"API request failed: {status_code} - {response_text}")
+
+
+def clear_error_handler() -> None:
+    """Clear the configured error handler (mainly for testing)."""
+    global _error_handler
+    _error_handler = None
+    logger.info("Error handler cleared")


### PR DESCRIPTION
## 🎯 What is the purpose/goal of this PR?

Add OAuth header injection support and configurable request context for different MCP deployment scenarios (e.g., remote MCP with OAuth authentication).

## ℹ️ Summarize the changes made

- **Added `context.py` module**: Provides a plugin system for injecting deployment-specific context (headers, metadata, error handlers) into API requests without modifying tool code
  - `set_request_context_provider()`: Configure custom headers and metadata injection
  - `set_error_handler()`: Configure custom API error handling
  - `get_request_context()`: Retrieve current request context

- **Updated `tools/base.py`**:
  - Integrate context provider to inject custom headers (OAuth, user context) into all API requests
  - Enhanced logging with context metadata (stage, user_id, auth_source, user_origin)
  - Use configurable error handler instead of hardcoded error messages
  - Support list of `additional_instructions` (backward compatible with string)

## 📌 Related Resources

* Monday Kanban Card Link: <https://aiera-force.monday.com/boards/7610926381/>
* Slack Thread Link:
* Updated/New Documentation Link: See docstrings in `aiera_mcp/context.py`

## Test Flows

- [x] Verify existing MCP functionality works without context provider (backward compatible)
- [x] Test OAuth header injection with configured context provider
- [x] Verify enhanced logging includes context metadata
- [x] Confirm custom error handler is called for API errors
- [x] Test that all existing tools continue to work unchanged

## 🚀 Checklist before requesting a review

- [x] I have performed a self-review/test of my code locally with the above documented test flows
- [ ] I have performed a self-review/test of my code on dev/staging (_not available on all repos_)
- [x] I have documented the required test flows on the this PR
- [x] I have made corresponding changes to the documentation or added new documentation where needed
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] There are **NO** security concerns with the changes made

**Note**: Dev/staging testing not applicable for this repo.




