### PR TITLE
Tool for identifying user-specific available tools

### DIFF
--- a/aiera_mcp/__init__.py
+++ b/aiera_mcp/__init__.py
@@ -126,6 +126,7 @@ AVAILABLE_TOOLS = [
     # Common/Utility Tools
     "get_grammar_template",
     "get_core_instructions",
+    "available_tools",
 ]
 
 # Convenience tool groups for common use cases
@@ -169,7 +170,7 @@ SEARCH_TOOLS = [
     "search_thirdbridge",
 ]
 WEB_TOOLS = ["trusted_web_search"]
-COMMON_TOOLS = ["get_grammar_template", "get_core_instructions"]
+COMMON_TOOLS = ["get_grammar_template", "get_core_instructions", "available_tools"]
 EMBEDDING_SEARCH_PIPELINE = "embedding_pipeline"
 HYBRID_SEARCH_PIPELINE = "hybrid_search_pipeline"
 
@@ -212,7 +213,7 @@ from .tools.search import (
     search_thirdbridge,
 )
 from .tools.web import trusted_web_search
-from .tools.common import get_grammar_template, get_core_instructions
+from .tools.common import get_grammar_template, get_core_instructions, available_tools
 
 # Import configuration
 from .config import get_settings, reload_settings, AieraSettings
@@ -282,6 +283,7 @@ __all__ = [
     "trusted_web_search",
     "get_grammar_template",
     "get_core_instructions",
+    "available_tools",
     # Utilities
     "make_aiera_request",
     "correct_bloomberg_ticker",

--- a/aiera_mcp/tools/common/__init__.py
+++ b/aiera_mcp/tools/common/__init__.py
@@ -18,8 +18,11 @@ from .models import (
     # Core instructions
     GetCoreInstructionsArgs,
     GetCoreInstructionsResponse,
+    # Available tools
+    AvailableToolsArgs,
+    AvailableToolsResponse,
 )
-from .tools import get_grammar_template, get_core_instructions
+from .tools import get_grammar_template, get_core_instructions, available_tools
 
 __all__ = [
     "BaseAieraArgs",
@@ -34,4 +37,7 @@ __all__ = [
     "GetCoreInstructionsArgs",
     "GetCoreInstructionsResponse",
     "get_core_instructions",
+    "AvailableToolsArgs",
+    "AvailableToolsResponse",
+    "available_tools",
 ]

--- a/aiera_mcp/tools/common/models.py
+++ b/aiera_mcp/tools/common/models.py
@@ -141,3 +141,23 @@ class GetCoreInstructionsResponse(BaseAieraResponse):
     """Response for get_core_instructions tool - passes through the API response structure."""
 
     response: Optional[Any] = Field(None, description="Response data from the API")
+
+
+class AvailableToolsArgs(BaseAieraArgs):
+    """Retrieve the list of tools available to the current user based on their permissions.
+
+    WHEN TO USE:
+    - Call this tool to discover which tools the current user has access to.
+    - Use this to check permissions before calling other tools.
+    """
+
+    pass
+
+
+class AvailableToolsResponse(BaseAieraResponse):
+    """Response for available_tools tool."""
+
+    available_tools: List[str] = Field(
+        default=[],
+        description="List of tool names available to the current user",
+    )

--- a/aiera_mcp/tools/common/tools.py
+++ b/aiera_mcp/tools/common/tools.py
@@ -11,6 +11,8 @@ from .models import (
     GetGrammarTemplateResponse,
     GetCoreInstructionsArgs,
     GetCoreInstructionsResponse,
+    AvailableToolsArgs,
+    AvailableToolsResponse,
 )
 
 # Setup logging
@@ -61,3 +63,80 @@ async def get_core_instructions(
 
     response = GetCoreInstructionsResponse.model_validate(raw_response)
     return response
+
+
+# Mapping from API endpoint paths to tool names.
+# Some endpoints map to multiple tools (e.g. get_event reuses the find-events endpoint).
+ENDPOINT_TO_TOOLS = {
+    "/chat-support/find-events": ["find_events", "get_event"],
+    "/chat-support/find-conferences": ["find_conferences"],
+    "/chat-support/estimated-and-upcoming-events": ["get_upcoming_events"],
+    "/chat-support/find-filings": ["find_filings", "get_filing"],
+    "/chat-support/find-equities": ["find_equities"],
+    "/chat-support/equity-summaries": ["get_equity_summaries"],
+    "/chat-support/available-watchlists": ["get_available_watchlists"],
+    "/chat-support/available-indexes": ["get_available_indexes"],
+    "/chat-support/get-sectors-and-subsectors": ["get_sectors_and_subsectors"],
+    "/chat-support/index-constituents": ["get_index_constituents"],
+    "/chat-support/watchlist-constituents": ["get_watchlist_constituents"],
+    "/chat-support/get-financials": ["get_financials"],
+    "/chat-support/get-ratios": ["get_ratios"],
+    "/chat-support/get-segments-and-kpis": ["get_kpis_and_segments"],
+    "/chat-support/find-company-docs": ["find_company_docs", "get_company_doc"],
+    "/chat-support/get-company-doc-categories": ["get_company_doc_categories"],
+    "/chat-support/get-company-doc-keywords": ["get_company_doc_keywords"],
+    "/chat-support/find-third-bridge": [
+        "find_third_bridge_events",
+        "get_third_bridge_event",
+    ],
+    "/chat-support/find-research": ["find_research", "get_research"],
+    "/chat-support/get-research-providers": ["get_research_providers"],
+    "/chat-support/get-research-authors": ["get_research_authors"],
+    "/chat-support/get-research-asset-classes": ["get_research_asset_classes"],
+    "/chat-support/get-research-asset-types": ["get_research_asset_types"],
+    "/chat-support/get-research-subjects": ["get_research_subjects"],
+    "/chat-support/get-research-product-focuses": ["get_research_product_focuses"],
+    "/chat-support/get-research-region-types": ["get_research_region_types"],
+    "/chat-support/get-research-country-codes": ["get_research_country_codes"],
+    "/chat-support/search/transcripts": ["search_transcripts"],
+    "/chat-support/search/filings": ["search_filings"],
+    "/chat-support/search/filing-chunks": ["search_filings"],
+    "/chat-support/search/research": ["search_research"],
+    "/chat-support/search/research-chunks": ["search_research"],
+    "/chat-support/search/company-docs": ["search_company_docs"],
+    "/chat-support/search/company-doc-chunks": ["search_company_docs"],
+    "/chat-support/search/thirdbridge": ["search_thirdbridge"],
+    "/chat-support/trusted-web": ["trusted_web_search"],
+    "/chat-support/get-grammar-template": ["get_grammar_template"],
+    "/chat-support/get-core-instructions": ["get_core_instructions"],
+}
+
+
+async def available_tools(
+    args: AvailableToolsArgs,
+) -> AvailableToolsResponse:
+    """Retrieve the list of tools available to the current user."""
+    logger.info("tool called: available_tools")
+
+    client = await get_http_client(None)
+    api_key = get_api_key()
+
+    raw_response = await make_aiera_request(
+        client=client,
+        method="GET",
+        endpoint="/chat-support/available-endpoints",
+        api_key=api_key,
+        params={},
+    )
+
+    endpoints = raw_response.get("endpoints", [])
+
+    tool_names = set()
+    for endpoint in endpoints:
+        tools = ENDPOINT_TO_TOOLS.get(endpoint, [])
+        tool_names.update(tools)
+
+    # Always include available_tools itself
+    tool_names.add("available_tools")
+
+    return AvailableToolsResponse(available_tools=sorted(tool_names))

--- a/aiera_mcp/tools/registry.py
+++ b/aiera_mcp/tools/registry.py
@@ -44,7 +44,7 @@ from .research import (
     get_research_country_codes,
 )
 from .web import trusted_web_search
-from .common import get_grammar_template, get_core_instructions
+from .common import get_grammar_template, get_core_instructions, available_tools
 from .search import (
     search_transcripts,
     search_filings,
@@ -93,7 +93,7 @@ from .research import (
     GetResearchCountryCodesArgs,
 )
 from .web import TrustedWebSearchArgs
-from .common import GetGrammarTemplateArgs, GetCoreInstructionsArgs
+from .common import GetGrammarTemplateArgs, GetCoreInstructionsArgs, AvailableToolsArgs
 from .search import (
     SearchTranscriptsArgs,
     SearchFilingsArgs,
@@ -459,6 +459,15 @@ TOOL_REGISTRY = {
         "input_schema": GetCoreInstructionsArgs.model_json_schema(),
         "function": get_core_instructions,
         "args_model": GetCoreInstructionsArgs,
+        "category": "common",
+        "read_only": True,
+        "destructive": False,
+    },
+    "available_tools": {
+        "display_name": "Available Tools",
+        "input_schema": AvailableToolsArgs.model_json_schema(),
+        "function": available_tools,
+        "args_model": AvailableToolsArgs,
         "category": "common",
         "read_only": True,
         "destructive": False,


### PR DESCRIPTION
Add available_tools tool for user permission discovery
                                                                                                                                                                                                                  
  Summary                                

  - Adds a new available_tools MCP tool that calls GET /chat-support/available-endpoints to retrieve the user's permitted API endpoints and translates them into the corresponding list of tool names             
  - Maintains an ENDPOINT_TO_TOOLS mapping that handles one-to-many relationships (e.g. /find-events maps to both find_events and get_event) and search endpoint variants (e.g. both /search/filings and
  /search/filing-chunks map to search_filings)                                                                                                                                                                    
  - The tool always includes itself in the response and returns a sorted, deduplicated list
                                                                                                                                                                                                                  
  Test plan                              
                                                                                                                                                                                                                  
  - All 393 existing tests pass                                                                                                                                                                                   
  - Manual test: call available_tools with a fully-permissioned API key and verify all expected tools are returned
  - Manual test: call available_tools with a restricted API key and verify only permitted tools are returned                                                                                                      
  - Verify unmapped endpoints from the API are silently ignored (no errors) 