### PR TITLE
May 8 Log Fixes

### DIFF
--- a/aiera_mcp/tools/base.py
+++ b/aiera_mcp/tools/base.py
@@ -20,6 +20,18 @@ DEFAULT_HEADERS = {
     "X-MCP-Origin": "local_mcp",
 }
 
+# Headers containing credentials — never log raw values.
+SENSITIVE_HEADERS = {"X-API-Key", "Authorization", "Cookie"}
+
+
+def _redact_headers(headers: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of headers with sensitive values replaced by a marker."""
+    return {
+        key: ("***REDACTED***" if key in SENSITIVE_HEADERS else value)
+        for key, value in headers.items()
+    }
+
+
 # Public constant for backward compatibility
 # Note: This is evaluated at import time; for dynamic access use get_settings().aiera_base_url
 AIERA_BASE_URL = get_settings().aiera_base_url
@@ -322,7 +334,7 @@ async def make_aiera_request(
                     f"Request failed after {MAX_ATTEMPTS} attempts for {endpoint}: {type(e).__name__}: {e}"
                 )
                 logger.error(f"Request URL was: {url}")
-                logger.error(f"Request headers were: {headers}")
+                logger.error(f"Request headers were: {_redact_headers(headers)}")
                 if params:
                     logger.error(f"Request params were: {params}")
 
@@ -333,7 +345,7 @@ async def make_aiera_request(
                 f"Request timed out after {settings.http_timeout}s for {endpoint}: {type(e).__name__}: {e}"
             )
             logger.error(f"Request URL was: {url}")
-            logger.error(f"Request headers were: {headers}")
+            logger.error(f"Request headers were: {_redact_headers(headers)}")
             if params:
                 logger.error(f"Request params were: {params}")
 
@@ -345,7 +357,7 @@ async def make_aiera_request(
         except httpx.RequestError as e:
             # Other request errors (not transient) - fail immediately
             logger.error(f"Request URL was: {url}")
-            logger.error(f"Request headers were: {headers}")
+            logger.error(f"Request headers were: {_redact_headers(headers)}")
             if params:
                 logger.error(f"Request params were: {params}")
 
@@ -354,7 +366,7 @@ async def make_aiera_request(
     if response.status_code not in [200, 201]:
         logger.error(f"API error: {response.status_code} - {response.text}")
         logger.error(f"Request URL: {url}")
-        logger.error(f"Request headers were: {headers}")
+        logger.error(f"Request headers were: {_redact_headers(headers)}")
         if params:
             logger.error(f"Request params: {params}")
 

--- a/aiera_mcp/tools/base.py
+++ b/aiera_mcp/tools/base.py
@@ -20,14 +20,15 @@ DEFAULT_HEADERS = {
     "X-MCP-Origin": "local_mcp",
 }
 
-# Headers containing credentials — never log raw values.
-SENSITIVE_HEADERS = {"X-API-Key", "Authorization", "Cookie"}
+# Headers containing credentials — never log raw values. Compared case-insensitively
+# since HTTP header names are case-insensitive per RFC 7230.
+SENSITIVE_HEADERS = {"x-api-key", "authorization", "cookie"}
 
 
 def _redact_headers(headers: Dict[str, Any]) -> Dict[str, Any]:
     """Return a copy of headers with sensitive values replaced by a marker."""
     return {
-        key: ("***REDACTED***" if key in SENSITIVE_HEADERS else value)
+        key: ("***REDACTED***" if key.lower() in SENSITIVE_HEADERS else value)
         for key, value in headers.items()
     }
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from aiera_mcp.tools.base import make_aiera_request
+from aiera_mcp.tools.base import _redact_headers, make_aiera_request
 
 
 def _ok_response(json_payload=None):
@@ -125,3 +125,98 @@ class TestMakeAieraRequestRetries:
             )
 
         assert client.request.await_count == 1
+
+
+@pytest.mark.unit
+class TestRedactHeaders:
+    def test_redacts_api_key(self):
+        out = _redact_headers(
+            {"X-API-Key": "sekret", "Content-Type": "application/json"}
+        )
+        assert out["X-API-Key"] == "***REDACTED***"
+        assert out["Content-Type"] == "application/json"
+
+    def test_redacts_authorization_and_cookie(self):
+        out = _redact_headers(
+            {"Authorization": "Bearer abc", "Cookie": "session=xyz", "User-Agent": "ua"}
+        )
+        assert out["Authorization"] == "***REDACTED***"
+        assert out["Cookie"] == "***REDACTED***"
+        assert out["User-Agent"] == "ua"
+
+    def test_does_not_mutate_input(self):
+        original = {"X-API-Key": "sekret"}
+        _redact_headers(original)
+        assert original["X-API-Key"] == "sekret"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestApiKeyNeverLogged:
+    async def test_api_key_not_in_error_logs_on_timeout(self, caplog):
+        import logging
+
+        client = MagicMock()
+        client.request = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+
+        api_key = "this-key-must-not-leak-abc123"
+        with caplog.at_level(logging.ERROR), pytest.raises(Exception):
+            await make_aiera_request(
+                client=client,
+                method="GET",
+                endpoint="/test",
+                api_key=api_key,
+            )
+
+        full_log = "\n".join(record.getMessage() for record in caplog.records)
+        assert api_key not in full_log
+        assert "***REDACTED***" in full_log
+
+    async def test_api_key_not_in_error_logs_on_connect_error(
+        self, caplog, monkeypatch
+    ):
+        import logging
+
+        async def fast_sleep(_):
+            return None
+
+        monkeypatch.setattr("aiera_mcp.tools.base.asyncio.sleep", fast_sleep)
+
+        client = MagicMock()
+        client.request = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+        api_key = "this-key-must-not-leak-xyz456"
+        with caplog.at_level(logging.ERROR), pytest.raises(Exception):
+            await make_aiera_request(
+                client=client,
+                method="GET",
+                endpoint="/test",
+                api_key=api_key,
+            )
+
+        full_log = "\n".join(record.getMessage() for record in caplog.records)
+        assert api_key not in full_log
+        assert "***REDACTED***" in full_log
+
+    async def test_api_key_not_in_error_logs_on_non_2xx(self, caplog):
+        import logging
+
+        bad_response = MagicMock()
+        bad_response.status_code = 500
+        bad_response.text = "boom"
+
+        client = MagicMock()
+        client.request = AsyncMock(return_value=bad_response)
+
+        api_key = "this-key-must-not-leak-pqr789"
+        with caplog.at_level(logging.ERROR), pytest.raises(Exception):
+            await make_aiera_request(
+                client=client,
+                method="GET",
+                endpoint="/test",
+                api_key=api_key,
+            )
+
+        full_log = "\n".join(record.getMessage() for record in caplog.records)
+        assert api_key not in full_log
+        assert "***REDACTED***" in full_log

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -149,6 +149,18 @@ class TestRedactHeaders:
         _redact_headers(original)
         assert original["X-API-Key"] == "sekret"
 
+    def test_case_insensitive_match(self):
+        out = _redact_headers(
+            {
+                "x-api-key": "sekret-lower",
+                "X-Api-Key": "sekret-mixed",
+                "AUTHORIZATION": "Bearer xyz",
+            }
+        )
+        assert out["x-api-key"] == "***REDACTED***"
+        assert out["X-Api-Key"] == "***REDACTED***"
+        assert out["AUTHORIZATION"] == "***REDACTED***"
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio


### PR DESCRIPTION
- aiera_mcp/tools/base.py: Added SENSITIVE_HEADERS = {"X-API-Key", "Authorization", "Cookie"} and _redact_headers() helper. All 4 logger.error(f"Request headers were: {headers}") sites now use the redacted
  version.
  - tests/unit/test_base.py: Added 6 tests:
    - TestRedactHeaders (3): redaction of X-API-Key, also Authorization + Cookie, no input mutation
    - TestApiKeyNeverLogged (3): verifies the raw API key never appears in log output across all three error paths (timeout, connect error, non-2xx response), and confirms ***REDACTED*** does appear