### PR TITLE
May 24 Fixes

### DIFF
--- a/aiera_mcp/tools/base.py
+++ b/aiera_mcp/tools/base.py
@@ -33,6 +33,37 @@ def _redact_headers(headers: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+# Cap response-body snippets in error logs to avoid dumping multi-KB HTML pages.
+MAX_RESPONSE_TEXT_IN_LOG = 500
+
+
+def _log_request_error(
+    msg: str,
+    url: str,
+    headers: Dict[str, Any],
+    params: Optional[Dict[str, Any]] = None,
+    response_text: Optional[str] = None,
+) -> None:
+    """Emit a single structured ERROR log for a failed upstream request.
+
+    Consolidates what used to be 4 separate logger.error calls (URL, headers,
+    params, body) into one entry. Context fields land under `extra` so they
+    surface as Datadog facets, and response body snippets are capped.
+    """
+    extra: Dict[str, Any] = {
+        "request_url": url,
+        "request_headers": _redact_headers(headers),
+    }
+    if params:
+        extra["request_params"] = params
+    if response_text:
+        snippet = response_text[:MAX_RESPONSE_TEXT_IN_LOG]
+        if len(response_text) > MAX_RESPONSE_TEXT_IN_LOG:
+            snippet += "...[truncated]"
+        extra["response_text"] = snippet
+    logger.error(msg, extra=extra)
+
+
 # Public constant for backward compatibility
 # Note: This is evaluated at import time; for dynamic access use get_settings().aiera_base_url
 AIERA_BASE_URL = get_settings().aiera_base_url
@@ -341,25 +372,23 @@ async def make_aiera_request(
                 await asyncio.sleep(wait_time)
 
             else:
-                logger.error(
-                    f"Request failed after {MAX_ATTEMPTS} attempts for {endpoint}: {type(e).__name__}: {e}"
+                _log_request_error(
+                    f"Request failed after {MAX_ATTEMPTS} attempts for {endpoint}: "
+                    f"{type(e).__name__}: {e}",
+                    url=url,
+                    headers=headers,
+                    params=params,
                 )
-                logger.error(f"Request URL was: {url}")
-                logger.error(f"Request headers were: {_redact_headers(headers)}")
-                if params:
-                    logger.error(f"Request params were: {params}")
-
                 raise Exception(f"Network error calling Aiera API: {str(e)}")
 
         except httpx.TimeoutException as e:
-            logger.error(
-                f"Request timed out after {settings.http_timeout}s for {endpoint}: {type(e).__name__}: {e}"
+            _log_request_error(
+                f"Request timed out after {settings.http_timeout}s for {endpoint}: "
+                f"{type(e).__name__}: {e}",
+                url=url,
+                headers=headers,
+                params=params,
             )
-            logger.error(f"Request URL was: {url}")
-            logger.error(f"Request headers were: {_redact_headers(headers)}")
-            if params:
-                logger.error(f"Request params were: {params}")
-
             raise Exception(
                 f"Aiera API request timed out after {settings.http_timeout}s. "
                 f"The API may be experiencing heavy load. Please retry in a moment."
@@ -367,19 +396,22 @@ async def make_aiera_request(
 
         except httpx.RequestError as e:
             # Other request errors (not transient) - fail immediately
-            logger.error(f"Request URL was: {url}")
-            logger.error(f"Request headers were: {_redact_headers(headers)}")
-            if params:
-                logger.error(f"Request params were: {params}")
-
+            _log_request_error(
+                f"Request error for {endpoint}: {type(e).__name__}: {e}",
+                url=url,
+                headers=headers,
+                params=params,
+            )
             raise Exception(f"Network error calling Aiera API: {str(e)}")
 
     if response.status_code not in [200, 201]:
-        logger.error(f"API error: {response.status_code} - {response.text}")
-        logger.error(f"Request URL: {url}")
-        logger.error(f"Request headers were: {_redact_headers(headers)}")
-        if params:
-            logger.error(f"Request params: {params}")
+        _log_request_error(
+            f"API error: {response.status_code} for {endpoint}",
+            url=url,
+            headers=headers,
+            params=params,
+            response_text=response.text,
+        )
 
         # Use custom error handler if configured, otherwise use default
         from ..context import handle_api_error

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -7,7 +7,13 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from aiera_mcp.tools.base import _redact_headers, _send_tool_log, make_aiera_request
+from aiera_mcp.tools.base import (
+    MAX_RESPONSE_TEXT_IN_LOG,
+    _log_request_error,
+    _redact_headers,
+    _send_tool_log,
+    make_aiera_request,
+)
 
 
 def _ok_response(json_payload=None):
@@ -180,9 +186,7 @@ class TestApiKeyNeverLogged:
                 api_key=api_key,
             )
 
-        full_log = "\n".join(record.getMessage() for record in caplog.records)
-        assert api_key not in full_log
-        assert "***REDACTED***" in full_log
+        _assert_api_key_redacted_across_records(caplog.records, api_key)
 
     async def test_api_key_not_in_error_logs_on_connect_error(
         self, caplog, monkeypatch
@@ -206,9 +210,7 @@ class TestApiKeyNeverLogged:
                 api_key=api_key,
             )
 
-        full_log = "\n".join(record.getMessage() for record in caplog.records)
-        assert api_key not in full_log
-        assert "***REDACTED***" in full_log
+        _assert_api_key_redacted_across_records(caplog.records, api_key)
 
     async def test_api_key_not_in_error_logs_on_non_2xx(self, caplog):
         import logging
@@ -229,9 +231,22 @@ class TestApiKeyNeverLogged:
                 api_key=api_key,
             )
 
-        full_log = "\n".join(record.getMessage() for record in caplog.records)
-        assert api_key not in full_log
-        assert "***REDACTED***" in full_log
+        _assert_api_key_redacted_across_records(caplog.records, api_key)
+
+
+def _assert_api_key_redacted_across_records(records, api_key):
+    """Verify the raw API key never appears in any log record (message or extra),
+    and that redaction did actually run (***REDACTED*** present somewhere)."""
+    saw_redaction = False
+    for record in records:
+        assert api_key not in record.getMessage()
+        headers = getattr(record, "request_headers", None)
+        if headers:
+            for value in headers.values():
+                assert api_key != value
+                if value == "***REDACTED***":
+                    saw_redaction = True
+    assert saw_redaction, "expected at least one redacted header in log records"
 
 
 @pytest.mark.unit
@@ -278,3 +293,171 @@ class TestSendToolLogAuthFailureIsSilent:
             "_send_tool_log should fail silently when the api-key provider "
             f"raises, got: {[r.getMessage() for r in bad]}"
         )
+
+
+@pytest.mark.unit
+class TestLogRequestError:
+    def test_emits_single_error_log(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.ERROR, logger="aiera_mcp.tools.base"):
+            _log_request_error(
+                "boom",
+                url="https://api.example.com/x",
+                headers={"X-API-Key": "sekret"},
+                params={"page": 1},
+                response_text="oops",
+            )
+
+        error_records = [r for r in caplog.records if r.name == "aiera_mcp.tools.base"]
+        assert len(error_records) == 1
+
+    def test_redacts_headers_in_extra(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.ERROR, logger="aiera_mcp.tools.base"):
+            _log_request_error(
+                "boom",
+                url="https://api.example.com/x",
+                headers={"X-API-Key": "leak-me", "User-Agent": "ua"},
+            )
+
+        record = caplog.records[-1]
+        assert record.request_headers == {
+            "X-API-Key": "***REDACTED***",
+            "User-Agent": "ua",
+        }
+        assert "leak-me" not in record.getMessage()
+
+    def test_truncates_long_response_text(self, caplog):
+        import logging
+
+        long_body = "x" * (MAX_RESPONSE_TEXT_IN_LOG + 50)
+        with caplog.at_level(logging.ERROR, logger="aiera_mcp.tools.base"):
+            _log_request_error(
+                "boom",
+                url="https://api.example.com/x",
+                headers={},
+                response_text=long_body,
+            )
+
+        record = caplog.records[-1]
+        snippet = record.response_text
+        assert len(snippet) <= MAX_RESPONSE_TEXT_IN_LOG + len("...[truncated]")
+        assert snippet.endswith("...[truncated]")
+
+    def test_omits_params_and_response_text_when_absent(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.ERROR, logger="aiera_mcp.tools.base"):
+            _log_request_error(
+                "boom",
+                url="https://api.example.com/x",
+                headers={},
+            )
+
+        record = caplog.records[-1]
+        assert not hasattr(record, "request_params")
+        assert not hasattr(record, "response_text")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestConsolidatedErrorLogging:
+    async def test_non_2xx_emits_single_error_log(self, caplog):
+        import logging
+
+        bad_response = MagicMock()
+        bad_response.status_code = 502
+        bad_response.text = "<html>502 Bad Gateway</html>"
+
+        client = MagicMock()
+        client.request = AsyncMock(return_value=bad_response)
+
+        with (
+            caplog.at_level(logging.ERROR, logger="aiera_mcp.tools.base"),
+            pytest.raises(Exception),
+        ):
+            await make_aiera_request(
+                client=client,
+                method="GET",
+                endpoint="/test",
+                api_key="key",
+                params={"foo": "bar"},
+            )
+
+        error_records = [r for r in caplog.records if r.name == "aiera_mcp.tools.base"]
+        assert len(error_records) == 1
+        rec = error_records[0]
+        assert "502" in rec.getMessage()
+        assert rec.request_url.endswith("/test")
+        assert rec.request_headers["X-API-Key"] == "***REDACTED***"
+        assert rec.request_params == {"foo": "bar"}
+        assert "502" in rec.response_text
+
+    async def test_timeout_emits_single_error_log(self, caplog):
+        import logging
+
+        client = MagicMock()
+        client.request = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+
+        with (
+            caplog.at_level(logging.ERROR, logger="aiera_mcp.tools.base"),
+            pytest.raises(Exception),
+        ):
+            await make_aiera_request(
+                client=client,
+                method="GET",
+                endpoint="/test",
+                api_key="key",
+            )
+
+        error_records = [r for r in caplog.records if r.name == "aiera_mcp.tools.base"]
+        assert len(error_records) == 1
+
+    async def test_connect_error_emits_single_error_log(self, caplog, monkeypatch):
+        import logging
+
+        async def fast_sleep(_):
+            return None
+
+        monkeypatch.setattr("aiera_mcp.tools.base.asyncio.sleep", fast_sleep)
+
+        client = MagicMock()
+        client.request = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+        with (
+            caplog.at_level(logging.ERROR, logger="aiera_mcp.tools.base"),
+            pytest.raises(Exception),
+        ):
+            await make_aiera_request(
+                client=client,
+                method="GET",
+                endpoint="/test",
+                api_key="key",
+            )
+
+        error_records = [r for r in caplog.records if r.name == "aiera_mcp.tools.base"]
+        assert len(error_records) == 1
+
+    async def test_other_request_error_emits_single_error_log(self, caplog):
+        import logging
+
+        client = MagicMock()
+        client.request = AsyncMock(
+            side_effect=httpx.RemoteProtocolError("disconnected")
+        )
+
+        with (
+            caplog.at_level(logging.ERROR, logger="aiera_mcp.tools.base"),
+            pytest.raises(Exception),
+        ):
+            await make_aiera_request(
+                client=client,
+                method="GET",
+                endpoint="/test",
+                api_key="key",
+            )
+
+        error_records = [r for r in caplog.records if r.name == "aiera_mcp.tools.base"]
+        assert len(error_records) == 1


### PR DESCRIPTION
Each failed upstream request used to emit 4–5 separate logger.error lines (one for URL, one for headers, one for params, one for the API error or exception). At current 502/504 rates from graphql.aiera.com, that
   was producing ~10,900 error log lines/day — most of them duplicates of the same underlying failure. This PR consolidates all four error paths in make_aiera_request into a single structured ERROR log per
  failure.
  
  Changes

  aiera_mcp/tools/base.py
  - Added _log_request_error() helper that emits one logger.error() call with structured extra fields:
    - request_url
    - request_headers (passed through _redact_headers)
    - request_params (omitted when empty)
    - response_text (capped at 500 chars to avoid logging multi-KB HTML error pages)
  - Added MAX_RESPONSE_TEXT_IN_LOG = 500 constant for the body cap.
  - Replaced the 4 multi-line error sites with single calls to _log_request_error():
    - ConnectError final-retry branch (retry-exhausted)
    - TimeoutException branch
    - Other RequestError branch (non-transient)
    - Non-2xx response branch

  tests/unit/test_base.py — 8 new tests:
  - TestLogRequestError (4): single log line emitted, headers redacted in extra, response text truncated past the cap, optional fields omitted when absent.
  - TestConsolidatedErrorLogging (4): each of the four error paths (non-2xx, timeout, connect-error, other RequestError) emits exactly one ERROR log.
  - Updated TestApiKeyNeverLogged to check redaction in record.request_headers (the new structured field) via a helper, since the message text is now clean of header dumps.